### PR TITLE
Add CPU and RAM params (Fix #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ The following attributes are available to further configure the provider:
 - `provider.template` - A string representing the name of an availabe virtual
    machine template in the VDC. The available templates can be check in the 
    `Apps Library` section.
+- `provider.cpu_cores` - The number of CPU cores to assign to the virtual machine. If
+   missing, the required CPU from the template will be used.
+- `provider.ram_mb` - The amount of RAM in MB that will be assigned to the VM. If
+   missing, the required RAM from the template will be used.
 
 Run
 ---

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       abiquo_username: 'mcirauqui',
       abiquo_password: 'xxxx'
     }
+    provider.cpu_cores = 2
+    provider.ram_mb = 2048
     provider.virtualdatacenter = 'Support Lab - Marc'
     provider.virtualappliance = 'Tests'
     provider.template = 'Alpine Linux'

--- a/lib/vagrant-abiquo/actions/create.rb
+++ b/lib/vagrant-abiquo/actions/create.rb
@@ -1,5 +1,5 @@
 require 'vagrant-abiquo/helpers/client'
-
+require 'pry'
 module VagrantPlugins
   module Abiquo
     module Actions
@@ -41,8 +41,15 @@ module VagrantPlugins
           tmpl_link = template.link(:edit).clone.to_hash
           tmpl_link['rel'] = "virtualmachinetemplate"
           
+          # Configured CPU and RAM
+          cpu_cores = @machine.provider_config.cpu_cores
+          ram_mb = @machine.provider_config.ram_mb
+
           # VM entity
+          binding.pry
           vm_definition = {}
+          vm_definition['cpu'] = cpu_cores || template.cpuRequired
+          vm_definition['ram'] = ram_mb || template.ramRequired
           vm_definition['label'] = @machine.name
           vm_definition['vdrpEnabled'] = true
           vm_definition['links'] = [ tmpl_link ]

--- a/lib/vagrant-abiquo/actions/create.rb
+++ b/lib/vagrant-abiquo/actions/create.rb
@@ -1,5 +1,5 @@
 require 'vagrant-abiquo/helpers/client'
-require 'pry'
+
 module VagrantPlugins
   module Abiquo
     module Actions
@@ -46,7 +46,6 @@ module VagrantPlugins
           ram_mb = @machine.provider_config.ram_mb
 
           # VM entity
-          binding.pry
           vm_definition = {}
           vm_definition['cpu'] = cpu_cores || template.cpuRequired
           vm_definition['ram'] = ram_mb || template.ramRequired

--- a/lib/vagrant-abiquo/config.rb
+++ b/lib/vagrant-abiquo/config.rb
@@ -5,6 +5,8 @@ module VagrantPlugins
       attr_accessor :virtualdatacenter
       attr_accessor :virtualappliance
       attr_accessor :ssh_private_ips
+      attr_accessor :cpu_cores
+      attr_accessor :ram_mb
       attr_accessor :template
 
       def initialize
@@ -13,6 +15,8 @@ module VagrantPlugins
         @virtualappliance       = UNSET_VALUE
         @template               = UNSET_VALUE
         @ssh_private_ips        = false
+        @cpu_cores              = 0
+        @ram_mb                 = 0
       end
 
       def finalize!
@@ -25,6 +29,11 @@ module VagrantPlugins
         @template = ENV['ABQ_TMPL'] if ENV['ABQ_TMPL']
 
         @ssh_private_ips = ENV['ABQ_SSHPRIV'] if ENV['ABQ_SSHPRIV']
+
+        @cpu_cores = ENV['ABQ_CPU'] if ENV['ABQ_CPU']
+        @cpu_cores = nil if @cpu_cores == 0
+        @ram_mb = ENV['ABQ_RAM'] if ENV['ABQ_RAM']
+        @ram_mb = nil if @ram_mb == 0
       end
 
       def validate(machine)

--- a/lib/vagrant-abiquo/provider.rb
+++ b/lib/vagrant-abiquo/provider.rb
@@ -1,6 +1,6 @@
 require 'vagrant-abiquo/helpers/client'
 require 'abiquo-api'
-require 'pry'
+
 module VagrantPlugins
   module Abiquo
     class Provider < Vagrant.plugin('2', :provider)


### PR DESCRIPTION
Adds the following params:
- `cpu_cores` to setup the CPU.
- `ram_mb` to setup the RAM in MB.

If omitted, defaults from template will be used.