### PR TITLE
Userdata and concurrency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GIT
 PATH
   remote: .
   specs:
-    vagrant-abiquo (0.0.2)
+    vagrant_abiquo (0.0.2)
       abiquo-api (~> 0.1.1)
       log4r
 
@@ -143,7 +143,7 @@ DEPENDENCIES
   pry-byebug
   rake
   vagrant!
-  vagrant-abiquo!
+  vagrant_abiquo!
 
 BUNDLED WITH
-   1.14.3
+   1.14.5

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   
   config.vm.provider :abiquo do |provider, override|
     override.vm.box = 'abiquo'
-    override.vm.box_url = "https://github.com/smdahlen/vagrant-digitalocean/raw/master/box/digital_ocean.box"
+    override.vm.box_url = "https://github.com/abiquo/vagrant_abiquo/raw/master/box/abiquo.box"
     
     provider.abiquo_connection_data = {
       abiquo_api_url: 'http://mothership.bcn.abiquo.com/api',

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,30 +1,39 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.synced_folder ".", "/vagrant",type: "rsync"
-  
-  config.vm.define 'abiquotesting' do |t|
-  
+  config.vm.synced_folder ".", "/vagrant", type: "rsync"
+
+  (1..5).each do |index|
+    config.vm.define "abiquotesting#{index}" do |t|
+      t.vm.hostname = "abiquotesting#{index}"
+    end
   end
   
   config.vm.provider :abiquo do |provider, override|
     override.vm.box = 'abiquo'
-    override.vm.box_url = "https://github.com/smdahlen/vagrant-digitalocean/raw/master/box/digital_ocean.box"
+    override.vm.box_url = "https://github.com/abiquo/vagrant_abiquo/raw/master/box/abiquo.box"
     override.vm.hostname = 'abiquotesting'
 
     provider.abiquo_connection_data = {
-      abiquo_api_url: 'http://mothership.bcn.abiquo.com/api',
-      abiquo_username: 'mcirauqui',
-      abiquo_password: 'xxxx'
+      abiquo_api_url: 'https://chirauki40.bcn.abiquo.com/api',
+      abiquo_username: 'admin',
+      abiquo_password: 'xabiquo',
+      connection_options: {
+        ssl: {
+          verify: false
+        }
+      }
     }
     provider.cpu_cores = 2
     provider.ram_mb = 2048
-    provider.virtualdatacenter = 'Support Lab - Marc'
-    provider.virtualappliance = 'Tests'
-    provider.template = 'Alpine Linux'
+    provider.virtualdatacenter = 'ESX_VDC'
+    provider.virtualappliance = 'Vagrant Tests'
+    provider.template = 'Centos 7 x86_64'
 
     provider.network = {
       'private_dnsmasq' => nil
     }
+    override.ssh.private_key_path = '~/.ssh/id_rsa'
+    override.ssh.username = 'centos'
   end
 end

--- a/lib/vagrant_abiquo/actions.rb
+++ b/lib/vagrant_abiquo/actions.rb
@@ -38,10 +38,12 @@ module VagrantPlugins
               env[:ui].info I18n.t('vagrant_abiquo.info.already_active')
             when :OFF
               b.use PowerOn
-              b.use provision
+              b.use Provision
+              b.use SyncedFolders
             when :not_created
               b.use Create
-              b.use provision
+              b.use Provision
+              b.use SyncedFolders
             end
           end
         end

--- a/lib/vagrant_abiquo/actions/create_vapp.rb
+++ b/lib/vagrant_abiquo/actions/create_vapp.rb
@@ -1,0 +1,38 @@
+require 'vagrant_abiquo/helpers/client'
+require 'vagrant_abiquo/helpers/abiquo'
+
+module VagrantPlugins
+  module Abiquo
+    module Actions
+      class CreatevApp
+        include Helpers::Client
+        include Helpers::Abiquo
+        
+        def initialize(app, env)
+          @app = app
+          @machine = env[:machine]
+          @logger = Log4r::Logger.new('vagrant::abiquo::create_vapp')
+        end
+
+        def call(env)
+          pconfig = env[:env].vagrantfile.config.finalize![:vm].get_provider_config(:abiquo)
+          @client ||= AbiquoAPI.new(pconfig.abiquo_connection_data)
+
+          @logger.info "Checking vApp '#{pconfig.virtualappliance}'"
+
+          @logger.info "Looking up VDC '#{pconfig.virtualdatacenter}'"
+          vdc = get_vdc(pconfig.virtualdatacenter)
+          raise Abiquo::Errors::VDCNotFound, vdc: pconfig.virtualdatacenter if vdc.nil?
+
+          vapp = get_vapp(vdc, pconfig.virtualappliance)
+          if vapp.nil?
+            @logger.info "vApp '#{pconfig.virtualappliance}' does not exist, creating."
+            create_vapp(vdc, pconfig.virtualappliance)
+          end
+
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant_abiquo/actions/destroy.rb
+++ b/lib/vagrant_abiquo/actions/destroy.rb
@@ -24,7 +24,7 @@ module VagrantPlugins
           # Check when task finishes. This may take a while
           retryable(:tries => 120, :sleep => 5) do
             begin
-              raise Exception if vm.refresh
+              raise vm.label if vm.refresh
             rescue AbiquoAPIClient::NotFound
               env[:ui].info I18n.t('vagrant_abiquo.info.deleted', vm: @machine.name)
             end

--- a/lib/vagrant_abiquo/actions/reset.rb
+++ b/lib/vagrant_abiquo/actions/reset.rb
@@ -20,6 +20,13 @@ module VagrantPlugins
           env[:ui].info I18n.t('vagrant_abiquo.info.reloading')
           vm = get_vm(@machine.id)
           vm = reset(vm)
+
+          # Give time to the OS to boot.
+          retryable(:tries => 120, :sleep => 10) do
+            next if env[:interrupted]
+            raise 'not ready' if !@machine.communicate.ready?
+          end
+
           @app.call(env)
         end
       end

--- a/lib/vagrant_abiquo/config.rb
+++ b/lib/vagrant_abiquo/config.rb
@@ -8,6 +8,7 @@ module VagrantPlugins
       attr_accessor :ram_mb
       attr_accessor :template
       attr_accessor :network
+      attr_accessor :user_data
 
       def initialize
         @abiquo_connection_data = UNSET_VALUE
@@ -17,24 +18,28 @@ module VagrantPlugins
         @cpu_cores              = 0
         @ram_mb                 = 0
         @network                = UNSET_VALUE
+        @user_data              = UNSET_VALUE
       end
 
       def finalize!
-        @abiquo_connection_data[:abiquo_api_url] = ENV['ABQ_URL'] if ENV['ABQ_URL']
-        @abiquo_connection_data[:abiquo_username] = ENV['ABQ_USER'] if ENV['ABQ_USER']
-        @abiquo_connection_data[:abiquo_password] = ENV['ABQ_PASS'] if ENV['ABQ_PASS']
+        @abiquo_connection_data[:abiquo_api_url] = ENV['ABQ_URL'] if @abiquo_connection_data[:abiquo_api_url].nil?
+        @abiquo_connection_data[:abiquo_username] = ENV['ABQ_USER'] if @abiquo_connection_data[:abiquo_username].nil?
+        @abiquo_connection_data[:abiquo_password] = ENV['ABQ_PASS'] if @abiquo_connection_data[:abiquo_password].nil?
 
-        @virtualdatacenter = ENV['ABQ_VDC'] if ENV['ABQ_VDC']
-        @virtualappliance = ENV['ABQ_VAPP'] if ENV['ABQ_VAPP']
-        @template = ENV['ABQ_TMPL'] if ENV['ABQ_TMPL']
+        @virtualdatacenter = ENV['ABQ_VDC'] if @virtualdatacenter == UNSET_VALUE
+        @virtualappliance = ENV['ABQ_VAPP'] if @virtualappliance == UNSET_VALUE
+        @template = ENV['ABQ_TMPL'] if @template == UNSET_VALUE
 
-        @cpu_cores = ENV['ABQ_CPU'] if ENV['ABQ_CPU']
-        @cpu_cores = nil if @cpu_cores == 0
-        @ram_mb = ENV['ABQ_RAM'] if ENV['ABQ_RAM']
+        @cpu_cores = ENV['ABQ_CPU'] if @cpu_cores == 0
+        @ram_mb = ENV['ABQ_RAM'] if @ram_mb == 0
         @ram_mb = nil if @ram_mb == 0
 
-        @network = { ENV['ABQ_NET'] => ENV['ABQ_IP'] } if ENV['ABQ_NET'] && ENV['ABQ_IP']
-        @network = nil if @network == UNSET_VALUE
+        @network = { ENV['ABQ_NET'] => ENV['ABQ_IP'] } if @network == UNSET_VALUE
+
+        if @user_data == UNSET_VALUE
+          # We will make sure the SSH key is injected.
+          @user_data = '#!/bin/bash\necho "vagrant_abiquo :: making sure SSH key gets injected."'
+        end
       end
 
       def validate(machine)

--- a/lib/vagrant_abiquo/helpers/abiquo.rb
+++ b/lib/vagrant_abiquo/helpers/abiquo.rb
@@ -10,6 +10,10 @@ module VagrantPlugins
 
         @logger = Log4r::Logger.new('vagrant::abiquo::helper')
 
+        def vapp_name(machine)
+          machine.provider_config.virtualappliance.nil? ? File.basename(machine.env.cwd) : machine.provider_config.virtualappliance
+        end
+
         def get_vm(vm_url)
           vm_lnk = AbiquoAPI::Link.new :href => vm_url,
                                        :type => 'application/vnd.abiquo.virtualmachine+json',
@@ -108,7 +112,7 @@ module VagrantPlugins
           # Check when deploy finishes. This may take a while
           retryable(:tries => 120, :sleep => 15) do
             task = task.link(:self).get
-            raise Exception if task.state == 'STARTED'
+            raise vm.label if task.state == 'STARTED'
           end
 
           task
@@ -123,7 +127,7 @@ module VagrantPlugins
           # Check when task finishes. This may take a while
           retryable(:tries => 120, :sleep => 5) do
             task = task.link(:self).get
-            raise Exception if task.state == 'STARTED'
+            raise vm.label if task.state == 'STARTED'
           end
           vm.link(:edit).get
         end
@@ -144,7 +148,7 @@ module VagrantPlugins
           # Check when task finishes. This may take a while
           retryable(:tries => 120, :sleep => 5) do
             task = task.link(:self).get
-            raise Exception if task.state == 'STARTED'
+            raise vm.label if task.state == 'STARTED'
           end
           vm.link(:edit).get
         end
@@ -158,7 +162,7 @@ module VagrantPlugins
             # Check when task finishes. This may take a while
             retryable(:tries => 120, :sleep => 5) do
               task = task.link(:self).get
-              raise Exception if task.state == 'STARTED'
+              raise vm.label if task.state == 'STARTED'
             end
           end
           vm.link(:edit).get

--- a/lib/vagrant_abiquo/plugin.rb
+++ b/lib/vagrant_abiquo/plugin.rb
@@ -16,6 +16,11 @@ module VagrantPlugins
         require_relative 'provider'
         Provider
       end
+
+      action_hook(:create_vapp, :environment_load) do |hook|
+        require_relative 'actions/create_vapp.rb'
+        hook.prepend(Actions::CreatevApp)
+      end
     end
   end
 end

--- a/vagrant_abiquo.gemspec
+++ b/vagrant_abiquo.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'vagrant-abiquo/version'
+require 'vagrant_abiquo/version'
 
 Gem::Specification.new do |gem|
   gem.name          = "vagrant_abiquo"


### PR DESCRIPTION
Allows to specify user-data for the machines. In case no user data
is provided, a dummy script is added to ensure SSH keys are injected.

Also adds concurrency to the provider so multiple machines can be
created at once.